### PR TITLE
Update for language changes up to 0.58.1

### DIFF
--- a/examples/spl4/main.pony
+++ b/examples/spl4/main.pony
@@ -1,6 +1,7 @@
 use "../../reactive_streams"
 use "time"
 use "collections"
+use @printf[I32](fmt: Pointer[U8] tag, ...)
 
 primitive Defaults
   fun tag items(): U64 => 1000//1 << 20

--- a/examples/spl4/main.pony
+++ b/examples/spl4/main.pony
@@ -80,7 +80,7 @@ actor Proc is ManagedPublisher[Bool]
   new create() =>
     _broadcast = Broadcast[Bool](this, Defaults.cap())
 
-  fun ref _subscriber_manager(): SubscriberManager[Bool] =>
+  fun ref subscriber_manager(): SubscriberManager[Bool] =>
     _broadcast
 
   be on_subscribe(s: Subscription iso) =>
@@ -142,5 +142,5 @@ actor Pub is ManagedPublisher[Bool]
       end
     end
 
-  fun ref _subscriber_manager(): SubscriberManager[Bool] =>
+  fun ref subscriber_manager(): SubscriberManager[Bool] =>
     _broadcast

--- a/reactive_streams/managedpublisher.pony
+++ b/reactive_streams/managedpublisher.pony
@@ -2,7 +2,7 @@ interface tag ManagedPublisher[A: Any #share] is Publisher[A]
   """
   A ManagedPublisher must have a SubscriberManager and give access to it.
   """
-  fun ref _subscriber_manager(): SubscriberManager[A]
+  fun ref subscriber_manager(): SubscriberManager[A]
     """
     Return the SubscriberManager associated with this ManagedPublisher.
     """
@@ -11,16 +11,16 @@ interface tag ManagedPublisher[A: Any #share] is Publisher[A]
     """
     A ManagedPublisher must respond by calling SubscriberManager._on_subscribe.
     """
-    _subscriber_manager().on_subscribe(s)
+    subscriber_manager().on_subscribe(s)
 
   be on_request(s: Subscriber[A], n: U64) =>
     """
     A ManagedPublisher must respond by calling SubscriberManager._on_request.
     """
-    _subscriber_manager().on_request(s, n)
+    subscriber_manager().on_request(s, n)
 
   be on_cancel(s: Subscriber[A]) =>
     """
     A ManagedPublisher must respond by calling SubscriberManager._on_cancel.
     """
-    _subscriber_manager().on_cancel(s)
+    subscriber_manager().on_cancel(s)

--- a/reactive_streams/test.pony
+++ b/reactive_streams/test.pony
@@ -1,4 +1,4 @@
-use "ponytest"
+use "pony_test"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)

--- a/reactive_streams/test.pony
+++ b/reactive_streams/test.pony
@@ -25,7 +25,7 @@ actor _TestPublisher is ManagedPublisher[U64]
     _mgr = Unicast[U64](this, qbounds)
     _subs = subs
 
-  fun ref _subscriber_manager(): SubscriberManager[U64] =>
+  fun ref subscriber_manager(): SubscriberManager[U64] =>
     _mgr
 
   be test_one(sub: _TestSubscriber) =>


### PR DESCRIPTION
Various changes have occurred:
* FFIs need to be 'use'd
* interfaces can not have private methods
* `ponytest` was renamed to `pony_test`.

This PR is the minimum required to make it compile and have tests pass using ponyc 0.58.1

On interfaces not having private methods, I believe the method in question (`subscriber_manager()`) is not really intended to be public, but is used by the default implementations of the other methods in the interface. I have made it public but there might be a better way to achieve the intended goal.