### PR TITLE
Rename build-examples make target to examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -maxdepth 0 -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
 EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 
-test: unit-tests build-examples
+test: unit-tests examples
 
 unit-tests: $(tests_binary)
 	$^ --exclude=integration --sequential
@@ -37,7 +37,7 @@ $(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
 	$(PONYC) -o ${BUILD_DIR} $(SRC_DIR)
 
-build-examples: $(EXAMPLES_BINARIES)
+examples: $(EXAMPLES_BINARIES)
 
 $(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
@@ -62,4 +62,4 @@ all: test
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
-.PHONY: all build-examples clean TAGS test
+.PHONY: all examples clean TAGS test


### PR DESCRIPTION
Shorter, more natural target name.